### PR TITLE
Fix/around midnight date display issue

### DIFF
--- a/client/src/containers/UserActivities.jsx
+++ b/client/src/containers/UserActivities.jsx
@@ -91,23 +91,7 @@ export class UserActivities extends Component {
                   return (
                     <TableRow key={n._id}>
                       <TableCell numeric>
-                        {/* {lang === 'en-US'
-                          ? new Date(n.dateCompleted)
-                              .toUTCString()
-                              .split(' ')
-                              .slice(1, 4)
-                              .americanize = () => {
-                                let a = 1,
-                                  b = 2;
-                                [a, b] = [b, a];
-                              }
-                              .join(' ')
-                          : new Date(n.dateCompleted)
-                              .toUTCString()
-                              .split(' ')
-                              .slice(1, 4)
-                              .join(' ')} */
-                        this.americanize(n.dateCompleted)}
+                        {this.americanize(n.dateCompleted)}
                       </TableCell>
                       <TableCell>{n.activity}</TableCell>
                       <TableCell numeric>{n.points}</TableCell>

--- a/client/src/containers/UserActivities.jsx
+++ b/client/src/containers/UserActivities.jsx
@@ -41,7 +41,11 @@ export class UserActivities extends Component {
 
   render() {
     const { classes, activities, isAuthenticated } = this.props;
-
+    //console.log(typeof activities[0].dateCompleted);
+    const options = {
+      localeMatcher: 'lookup',
+      timeZone: 'UTC',
+    };
     return (
       <div>
         {isAuthenticated && (
@@ -69,7 +73,11 @@ export class UserActivities extends Component {
                   return (
                     <TableRow key={n._id}>
                       <TableCell numeric>
-                        {new Date(n.dateCompleted).toLocaleDateString()}
+                        {new Date(n.dateCompleted)
+                          .toUTCString()
+                          .split(' ')
+                          .slice(1, 3)
+                          .join(' ')}
                       </TableCell>
                       <TableCell>{n.activity}</TableCell>
                       <TableCell numeric>{n.points}</TableCell>

--- a/client/src/containers/UserActivities.jsx
+++ b/client/src/containers/UserActivities.jsx
@@ -48,15 +48,17 @@ export class UserActivities extends Component {
   }
 
   americanize = dateCompleted => {
-    let date = new Date(dateCompleted);
-    date = date.toUTCString();
-    date = date.split(' ');
-    date = date.slice(1, 4);
+    let date = new Date(dateCompleted)
+      .toUTCString()
+      .split(' ')
+      .slice(1, 4);
+
     if (this.state.lang === 'en-US') {
       let b = date[1];
       date[1] = date[0];
       date[0] = b;
     }
+
     date = date.join(' ');
     return date;
   };

--- a/client/src/containers/UserActivities.jsx
+++ b/client/src/containers/UserActivities.jsx
@@ -34,18 +34,17 @@ const styles = theme => ({
 });
 
 export class UserActivities extends Component {
-  state = {
-    lang: null,
-  };
-  handleDelete = id => {
-    this.props.deleteActivity(id);
-    this.props.fetchActivities(this.props.userPage._id);
-  };
+  state = {};
 
   componentDidMount() {
     const language = window.navigator.language;
     this.setState({ lang: language });
   }
+
+  handleDelete = id => {
+    this.props.deleteActivity(id);
+    this.props.fetchActivities(this.props.userPage._id);
+  };
 
   americanize = dateCompleted => {
     let date = new Date(dateCompleted)

--- a/client/src/containers/UserActivities.jsx
+++ b/client/src/containers/UserActivities.jsx
@@ -34,18 +34,36 @@ const styles = theme => ({
 });
 
 export class UserActivities extends Component {
+  state = {
+    lang: null,
+  };
   handleDelete = id => {
     this.props.deleteActivity(id);
     this.props.fetchActivities(this.props.userPage._id);
   };
 
+  componentDidMount() {
+    const language = window.navigator.language;
+    this.setState({ lang: language });
+  }
+
+  americanize = dateCompleted => {
+    let date = new Date(dateCompleted);
+    date = date.toUTCString();
+    date = date.split(' ');
+    date = date.slice(1, 4);
+    if (this.state.lang === 'en-US') {
+      let b = date[1];
+      date[1] = date[0];
+      date[0] = b;
+    }
+    date = date.join(' ');
+    return date;
+  };
+
   render() {
     const { classes, activities, isAuthenticated } = this.props;
-    //console.log(typeof activities[0].dateCompleted);
-    const options = {
-      localeMatcher: 'lookup',
-      timeZone: 'UTC',
-    };
+
     return (
       <div>
         {isAuthenticated && (
@@ -73,11 +91,23 @@ export class UserActivities extends Component {
                   return (
                     <TableRow key={n._id}>
                       <TableCell numeric>
-                        {new Date(n.dateCompleted)
-                          .toUTCString()
-                          .split(' ')
-                          .slice(1, 4)
-                          .join(' ')}
+                        {/* {lang === 'en-US'
+                          ? new Date(n.dateCompleted)
+                              .toUTCString()
+                              .split(' ')
+                              .slice(1, 4)
+                              .americanize = () => {
+                                let a = 1,
+                                  b = 2;
+                                [a, b] = [b, a];
+                              }
+                              .join(' ')
+                          : new Date(n.dateCompleted)
+                              .toUTCString()
+                              .split(' ')
+                              .slice(1, 4)
+                              .join(' ')} */
+                        this.americanize(n.dateCompleted)}
                       </TableCell>
                       <TableCell>{n.activity}</TableCell>
                       <TableCell numeric>{n.points}</TableCell>

--- a/client/src/containers/UserActivities.jsx
+++ b/client/src/containers/UserActivities.jsx
@@ -76,7 +76,7 @@ export class UserActivities extends Component {
                         {new Date(n.dateCompleted)
                           .toUTCString()
                           .split(' ')
-                          .slice(1, 3)
+                          .slice(1, 4)
                           .join(' ')}
                       </TableCell>
                       <TableCell>{n.activity}</TableCell>

--- a/client/src/containers/activities/ActivityDatePicker.jsx
+++ b/client/src/containers/activities/ActivityDatePicker.jsx
@@ -3,6 +3,7 @@ import { withStyles } from 'material-ui/styles';
 import MuiPickersUtilsProvider from 'material-ui-pickers/utils/MuiPickersUtilsProvider';
 import DateFnsUtils from 'material-ui-pickers/utils/date-fns-utils';
 import DatePicker from 'material-ui-pickers/DatePicker';
+import enLocale from 'date-fns/locale/en-GB';
 
 import { styles } from './exports';
 
@@ -24,7 +25,7 @@ class DateSelector extends Component {
   render() {
     const { classes, input, label } = this.props;
     return (
-      <MuiPickersUtilsProvider utils={DateFnsUtils}>
+      <MuiPickersUtilsProvider utils={DateFnsUtils} locale={enLocale}>
         <div>
           <DatePicker
             autoOk={true}

--- a/client/src/containers/activities/ActivityDatePicker.jsx
+++ b/client/src/containers/activities/ActivityDatePicker.jsx
@@ -3,7 +3,6 @@ import { withStyles } from 'material-ui/styles';
 import MuiPickersUtilsProvider from 'material-ui-pickers/utils/MuiPickersUtilsProvider';
 import DateFnsUtils from 'material-ui-pickers/utils/date-fns-utils';
 import DatePicker from 'material-ui-pickers/DatePicker';
-import enLocale from 'date-fns/locale/en-GB';
 
 import { styles } from './exports';
 
@@ -25,7 +24,7 @@ class DateSelector extends Component {
   render() {
     const { classes, input, label } = this.props;
     return (
-      <MuiPickersUtilsProvider utils={DateFnsUtils} locale={enLocale}>
+      <MuiPickersUtilsProvider utils={DateFnsUtils}>
         <div>
           <DatePicker
             autoOk={true}
@@ -38,9 +37,7 @@ class DateSelector extends Component {
             minDate="2018-01-01"
             onChange={this.handleChange}
             showTodayButton
-            value={
-              this.state[input.name] && this.state[input.name].toUTCString()
-            }
+            value={this.state[input.name]}
             {...input}
           />
         </div>

--- a/client/src/containers/activities/ActivityDatePicker.jsx
+++ b/client/src/containers/activities/ActivityDatePicker.jsx
@@ -26,7 +26,7 @@ class DateSelector extends Component {
             animateYearScrolling={false}
             className={classes.textField}
             disableFuture
-            format="MMM DD, YYYY"
+            format="DD MMM YYYY"
             label={label}
             maxDateMessage="You can't add future accomplishments!"
             minDate="2018-01-01"

--- a/client/src/containers/activities/ActivityDatePicker.jsx
+++ b/client/src/containers/activities/ActivityDatePicker.jsx
@@ -37,7 +37,9 @@ class DateSelector extends Component {
             minDate="2018-01-01"
             onChange={this.handleChange}
             showTodayButton
-            value={this.state[input.name]}
+            value={
+              this.state[input.name] && this.state[input.name].toUTCString()
+            }
             {...input}
           />
         </div>

--- a/client/src/containers/activities/ActivityDatePicker.jsx
+++ b/client/src/containers/activities/ActivityDatePicker.jsx
@@ -16,6 +16,11 @@ class DateSelector extends Component {
     });
   };
 
+  componentDidMount() {
+    const language = window.navigator.language;
+    this.setState({ lang: language });
+  }
+
   render() {
     const { classes, input, label } = this.props;
     return (
@@ -26,7 +31,7 @@ class DateSelector extends Component {
             animateYearScrolling={false}
             className={classes.textField}
             disableFuture
-            format="DD MMM YYYY"
+            format={this.state.lang === 'en-US' ? 'MMM DD YYYY' : 'DD MMM YYYY'}
             label={label}
             maxDateMessage="You can't add future accomplishments!"
             minDate="2018-01-01"


### PR DESCRIPTION
Issue: In production, at certain times of day, displayed date for an activity was a day ahead of the recorded date.

Cause: Date is saved in UTC format. toLocaleDateString was acting as expected, displaying the local date at the UTC time specified, which is indeed a day prior to the recorded date.

Fix: Use toUTCString() to format the date in the UTC time zone, & some string manipulation for brevity.

Dates are in European format now. Americans will find this fashionable because it's Euro-chic.

Test deploy: https://speedstudy-chingu.herokuapp.com/

Note: Commit order is wrong because I had to keep setting the time on my computer back to reproduce the bug:)


